### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   gradle-check:
     # https://github.com/actions/virtual-environments/
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   publish-to-github-pages:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   publish-release-v4:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
